### PR TITLE
Parameterize volume env var

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-VOLUME=/docker
+VOLUME=${VOLUME:-/docker}
 ALLOW=${ALLOW:-192.168.0.0/16 172.16.0.0/12}
 OWNER=${OWNER:-nobody}
 GROUP=${GROUP:-nogroup}


### PR DESCRIPTION
This PR parameterize the volume rsync target folder as an environment variable. The idea is that users can run the container with a different volume, so it is more flexible as a volume container (when using `volumes-from`).