### PR TITLE
disable reverse lookup

### DIFF
--- a/run
+++ b/run
@@ -12,6 +12,7 @@ gid = ${GROUP}
 use chroot = yes
 pid file = /var/run/rsyncd.pid
 log file = /dev/stdout
+reverse lookup = no
 
 [volume]
     hosts deny = *


### PR DESCRIPTION
Currently in my local setup each sync follows with time lag, following with error like this:
```
rsync_volume_1     | 2016/01/19 13:12:28 [9] name lookup failed for 192.168.99.1: Temporary failure in name resolution
rsync_volume_1     | 2016/01/19 13:12:28 [9] connect from UNKNOWN (192.168.99.1)
```

I think DNS lookup should be disabled, what do you think?