### PR TITLE
Made chown recursive in run.sh

### DIFF
--- a/run
+++ b/run
@@ -4,7 +4,7 @@ ALLOW=${ALLOW:-192.168.0.0/16 172.16.0.0/12}
 OWNER=${OWNER:-nobody}
 GROUP=${GROUP:-nogroup}
 
-chown "${OWNER}:${GROUP}" "${VOLUME}"
+chown -R "${OWNER}:${GROUP}" "${VOLUME}"
 
 [ -f /etc/rsyncd.conf ] || cat <<EOF > /etc/rsyncd.conf
 uid = ${OWNER}


### PR DESCRIPTION
I was running into an issue where I couldn't delete with rsync because some directory permission weren't respecting my ENV OWNER and ENV GROUP variables. This fixes that, and I thought it might be useful to others as well.
